### PR TITLE
Replace XML checklist schema with a JSON approach and integrate with …

### DIFF
--- a/src/app/util/Util-services.ts
+++ b/src/app/util/Util-services.ts
@@ -87,7 +87,8 @@ export class UtilService {
   }
 
   downloadTsvTemplate(checklistJson) {
-    return this.httpClient.post(environment.webinRestUrl + '/tab/tsv', checklistJson, { responseType: 'arraybuffer' });
+    // return this.httpClient.post(environment.webinRestUrl + '/tab/tsv', checklistJson, { responseType: 'arraybuffer' });
+    return this.httpClient.post(environment.spreadsheetGeneratorUrl + '/generate-tsv-from-checklist', checklistJson, { responseType: 'arraybuffer' });
   }
 
   getFileName(checklist, extension) {

--- a/src/app/webin-report.service.ts
+++ b/src/app/webin-report.service.ts
@@ -20,6 +20,7 @@ import { WebinReportServiceInterface } from './webin-report.service.interface';
 export class WebinReportService implements WebinReportServiceInterface {
 
   private _baseUrl = environment.webinReportServiceUrl;
+  private _jsonSchemaUrl = environment.schemaStoreUrl;
 
   constructor(private _webinAuthenticationService: WebinAuthenticationService, private _http: HttpClient) { }
 
@@ -160,6 +161,16 @@ export class WebinReportService implements WebinReportServiceInterface {
     params['type'] = type;
     const url: string = this._baseUrl + '/checklists/xml/*' + '?' + this.getUrlParams(params);
     return this._http.get(url, { responseType: 'text', observe: 'response' });
+  }
+
+  getChecklistSchemas() {
+    console.log("** getChecklistSchemas **");
+    return this._http.get(this._jsonSchemaUrl, { responseType: 'json', observe: 'response' });
+  }
+
+  getDereferencedSchema(schemaUrl: string) {
+    console.log("** getDereferencedSchema **", schemaUrl);
+    return this._http.get(schemaUrl, { responseType: 'json', observe: 'response' });
   }
 
   private getAll(reportType: string, status: string, rows: string, format: string) {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -10,6 +10,8 @@ export const environment = {
     webinAuthUrl: 'https://wwwdev.ebi.ac.uk/ena/dev/submit/webin/auth',
     webinReportServiceUrl: 'https://wwwdev.ebi.ac.uk/ena/dev/submit/report',
     webinAdminServiceUrl: 'https://wwwdev.ebi.ac.uk/ena/dev/submit/webin/auth/admin',
+    schemaStoreUrl: 'http://wp-np2-44:8080/biosamples/schema/store/api/v2/schemas/list',
+    spreadsheetGeneratorUrl: ' http://127.0.0.1:5000', // custom local spreadsheet generator, not deployed yet
     sourceAttributeHelperURL: 'https://wwwdev.ebi.ac.uk/ena/sah/',
     webinGdprServiceUrl: 'TODO',
     pupMedUrl: 'https://www.ebi.ac.uk/europepmc/webservices/rest/search',


### PR DESCRIPTION
Things done in this draft PR

- This Draft PR introduces changes to the way ENA checklists are handled within the webin-portal. Specifically, it transitions from XML-based checklists to a JSON-based approach. The JSON schema store is provided [here](http://wp-np2-44:8080/biosamples/schema/store/api/v2/schemas/list). 

- Additionally, a custom spreadsheet generator has been developed and integrated for generating TSV templates, tailored to ENA's JSON checklists. This is provided [here](https://github.com/enasequence/ena-spreadsheet-generator/tree/main). The current version uses a local URL for integration with the spreadsheet generator, but this will be updated once the generator is deployed to the K8S cluster.
